### PR TITLE
feat: add bpmn-to-code to Supportive Tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Add links through pull requests or create an issue to start a discussion.
 ### Supportive Tooling
 - [BPMeter](https://design.inf.usi.ch/software/bpmeter) - Measure the size and structural complexity of your BPMN models through a simple Web application.
 - [BPMNspector-fixSeqFlow](https://github.com/matthiasgeiger/BPMNspector-fixSeqFlow) - Fixing Sequence Flow Issues in BPMN models.
+- [bpmn-to-code](https://github.com/emaarco/bpmn-to-code) - Gradle and Maven plugin that generates type-safe APIs from BPMN models across multiple engines. Ships with process unit-testing utilities and AI skills to accelerate development.
 
 ## Operations and Administration
 - [OpenBPM Control](https://openbpm.io/) – Specialized admin environment for maintaining and supporting process applications without workflow interruptions.


### PR DESCRIPTION
Hi! I'd love to have **bpmn-to-code** listed here — great resource you've put together!

It's a Gradle and Maven plugin that bridges the gap between BPMN models and code: it generates type-safe, process-specific APIs directly from your BPMN files, supports multiple engines (including Zeebe/Camunda Platform 8), ships with utilities to unit-test BPMN processes, and includes AI skills to speed up development workflows.

I think it fits naturally under **Modeling Tools > Supportive Tooling** — it extends the value of BPMN models beyond documentation into actual runtime code.

Happy to adjust anything if needed!